### PR TITLE
Fix mode.js dependency lock file error

### DIFF
--- a/.github/workflows/lint-only.yml
+++ b/.github/workflows/lint-only.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
+          cache-dependency-path: frontend-react/package-lock.json
       
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/test-pipeline.yml
+++ b/.github/workflows/test-pipeline.yml
@@ -78,6 +78,7 @@ jobs:
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
+        cache-dependency-path: frontend-react/package-lock.json
 
     - name: Install Python dependencies
       run: |
@@ -365,6 +366,7 @@ jobs:
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
+        cache-dependency-path: frontend-react/package-lock.json
 
     - name: Install dependencies
       run: |
@@ -473,6 +475,7 @@ jobs:
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
+        cache-dependency-path: frontend-react/package-lock.json
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Add `cache-dependency-path` to Node.js setup in GitHub Actions to fix dependency lock file not found errors.

The `actions/setup-node@v4` action was looking for `package-lock.json` in the root directory, but it is located in `frontend-react/`. This change directs the action to the correct path, resolving the "Dependencies lock file is not found" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-e757a647-76dc-4b5d-b800-6a437fa76a14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e757a647-76dc-4b5d-b800-6a437fa76a14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>